### PR TITLE
Ensure ThreadListener methods are called.

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/debugger/elements/AbstractDebugElement.java
+++ b/src/main/java/com/blazemeter/jmeter/debugger/elements/AbstractDebugElement.java
@@ -11,9 +11,10 @@ import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestIterationListener;
+import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContextService;
 
-public abstract class AbstractDebugElement<T> extends AbstractTestElement implements Wrapper<T>, OriginalLink<T>, LoopIterationListener, TestIterationListener {
+public abstract class AbstractDebugElement<T> extends AbstractTestElement implements Wrapper<T>, OriginalLink<T>, LoopIterationListener, TestIterationListener, ThreadListener {
     protected T wrapped;
     private T original;
 
@@ -69,6 +70,20 @@ public abstract class AbstractDebugElement<T> extends AbstractTestElement implem
     public void testIterationStart(LoopIterationEvent event) {
         if (wrapped instanceof TestIterationListener) {
             ((TestIterationListener) wrapped).testIterationStart(event);
+        }
+    }
+
+    @Override
+    public void threadStarted() {
+        if (wrapped instanceof ThreadListener) {
+            ((ThreadListener) wrapped).threadStarted();
+        }
+    }
+
+    @Override
+    public void threadFinished() {
+        if (wrapped instanceof ThreadListener) {
+            ((ThreadListener) wrapped).threadFinished();
         }
     }
 }


### PR DESCRIPTION
Ensure `AbstractDebugElement` is also a `ThreadListener`, so that the we also call `threadStarted`/`threadFinished` on the wrapped test element if it implements `ThreadListener`. This fixes the issue with wrapped test elements who expect to be called on thread start to initialize e.g. thread locals.

In particular, this makes the RMI Sampler [1] work with the debugger, as that particular sampler depends on initializing a thread local containing a BeanShell interpreter on thread start; without this, the sampler NPEs due to the uninitialized thread local.

This should also make the debugger compatible with other standard JMeter elements, in particular the TCP Sampler, which also depends on some initialization in `threadStarted()`.

---
[1] https://github.com/jmibanez/jmeter-rmi-plugin/